### PR TITLE
allow supervisord to run redis correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,18 @@ FROM ubuntu:trusty
 ENV FRAPPE_USER frappe
 ENV ERPNEXT_APPS_JSON https://raw.githubusercontent.com/frappe/bench/master/install_scripts/erpnext-apps-master.json
 RUN useradd $FRAPPE_USER && mkdir /home/$FRAPPE_USER && chown -R $FRAPPE_USER.$FRAPPE_USER /home/$FRAPPE_USER
+
 WORKDIR /home/$FRAPPE_USER
 COPY setup.sh /
-RUN  bash /setup.sh
+
+RUN bash /setup.sh
 RUN apt-get -y remove build-essential python-dev python-software-properties libmariadbclient-dev libxslt1-dev libcrypto++-dev \
 libssl-dev  && apt-get -y autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/ /home/$FRAPPE_USER/.cache
-VOLUME ["/var/lib/mysql", "/home/frappe/frappe-bench/sites/site1.local/"]
+RUN sed -i 's/\(daemonize \)yes/\1no/g' /etc/redis/redis.conf
+
 COPY all.conf /etc/supervisor/conf.d/
+
+VOLUME ["/var/lib/mysql", "/home/frappe/frappe-bench/sites/site1.local/"]
 EXPOSE 80
 
 CMD ["/usr/bin/supervisord","-n"]


### PR DESCRIPTION
The `supervisor` daemon is set to `autorestart` redis.
However `redis` runs in runs daemonized by default and thus exits cleanly with exit code `0`.

So `supervisord` tries to restart this process over and over until it becomes `FATAL`.